### PR TITLE
fixed wrong python_requires statement (comma is treated as logical AND)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,10 @@ Changelog
 =========
 
 
-1.0.4 (unreleased)
+1.0.4 (2023-10-18)
 ------------------
 
-- Nothing changed yet.
+- fixed wrong python_requires statement in setup.py [muellers]
 
 
 1.0.3 (2019-08-26)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ long_description = '\n\n'.join([
 
 setup(
     name='collective.edtf_behavior',
-    version='1.0.4.dev0',
+    version='1.0.4',
     description="A EDTF behavior for Plone.",
     long_description=long_description,
     # Get more from https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "Framework :: Plone :: 5.2",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Operating System :: OS Independent",
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
@@ -40,7 +41,7 @@ setup(
     package_dir={'': 'src'},
     include_package_data=True,
     zip_safe=False,
-    python_requires="==2.7, >=3.7",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
     install_requires=[
         'setuptools',
         # -*- Extra requirements: -*-


### PR DESCRIPTION
With setuptools==42.0.2 'python_requires' was not taken into account so the wrong statement was not noticed at buildout. But with the newer version there is always error for python version